### PR TITLE
buildCheckMod - рефакторинг

### DIFF
--- a/src/bempriv.js
+++ b/src/bempriv.js
@@ -11,24 +11,20 @@ function extend(o1, o2) {
 }
 
 function buildCheckMod(modName, modVal) {
-    return modVal ?
-        Array.isArray(modVal) ?
-            function(block) {
-                var i = 0, len = modVal.length;
-                while (i < len) {
-                    if (block.hasMod(modName, modVal[i++])) {
-                        return true;
-                    }
-                }
-                return false;
-            } :
-            function(block) {
-                return block.hasMod(modName, modVal);
-            } :
-        function(block) {
-            return block.hasMod(modName);
-        };
+
+    if (!modVal) {
+        return function(block) { return block.hasMod(modName); };
+    }
+
+    if (!Array.isArray(modVal)) {
+        return function(block) { return block.hasMod(modName, modVal); };
+    }
+
+    return function(block) {
+        return modVal.some(block.hasMod.bind(block, modName));
+    };
 }
+
 var toStr = Object.prototype.toString;
 function isFunction(obj) {
     return toStr.call(obj) === '[object Function]';
@@ -287,10 +283,11 @@ var BEMPRIV = inherit(/** @lends BEMPRIV.prototype */ {
     _name : 'bem',
 
     /**
-     * Declares blocks and creates a block class
+     * Declares blocks and elements, and creates a block class
      * @param {String} decl Block name (simple syntax) or description
      * @param {String} decl.block|decl.name Block name
      * @param {String} [decl.baseBlock] Name of the parent block
+     * @param {String} [decl.elem] Name of the declared elements
      * @param {Array} [decl.baseMix] Mixed block names
      * @param {Object} [props] Methods
      * @param {Object} [staticProps] Static methods


### PR DESCRIPTION
Пока смотрю на бемпривы, и разбираюсь - первый pr.
Делает код проще и читабельнее имхо на порядок. Код полностью по поведению эквивалентный. По приборам кажется ничего не замедлилось. (хотя приборы странные)

С  моими правками:

```
BEMPRIV.create x 3,866,503 ops/sec ±0.57% (97 runs sampled)
BEMPRIV.static:
BEMPRIV.json x 3,292,211 ops/sec ±0.35% (95 runs sampled)
Plain Object x 18,947,272 ops/sec ±2.05% (93 runs sampled)
Plain Function x 33,339,250 ops/sec ±2.73% (73 runs sampled)
Fastest is Plain Function
```

Без них:

```
BEMPRIV.create x 3,779,908 ops/sec ±0.59% (94 runs sampled)
BEMPRIV.static:
BEMPRIV.json x 3,283,533 ops/sec ±0.33% (99 runs sampled)
Plain Object x 18,841,005 ops/sec ±1.78% (88 runs sampled)
Plain Function x 33,797,902 ops/sec ±1.97% (80 runs sampled)
Fastest is Plain Function
```
